### PR TITLE
A number of changes focused on getting random polymer builds working

### DIFF
--- a/examples/generate_random_structures/get_initial_structure.py
+++ b/examples/generate_random_structures/get_initial_structure.py
@@ -4,14 +4,14 @@ from foldamers.cg_model.cgmodel import CGModel
 from cg_openmm.utilities.iotools import write_pdbfile_without_topology
 
 # Coarse grained model settings
-polymer_length = 24
-backbone_lengths = [1]
-sidechain_lengths = [1]
+polymer_length = 12
+backbone_lengths = [2]
+sidechain_lengths = [2]
 sidechain_positions = [0]
 include_bond_forces = True
 include_bond_angle_forces = True
 include_nonbonded_forces = True
-include_torsion_forces = False  # not sure why, but these need to be off for now.
+include_torsion_forces = False  # not sure why, but these need to be 'False' for now.
 constrain_bonds = False
 random_positions = True
 
@@ -39,40 +39,41 @@ epsilon = 0.1 * unit.kilojoule_per_mole
 epsilons = {"bb_eps": epsilon, "sc_eps": epsilon}
 
 # Bond angle definitions
-bond_angle_force_constant = 15.0 * unit.kilojoules_per_mole / unit.radian / unit.radian
+bond_angle_force_constant = 15.0 * unit.kilojoule_per_mole / unit.radian / unit.radian
 bond_angle_force_constants = {
     "bb_bb_bb_angle_k": bond_angle_force_constant,
     "bb_bb_sc_angle_k": bond_angle_force_constant,
     "bb_sc_sc_angle_k": bond_angle_force_constant,
 }
+
 bb_bb_bb_equil_bond_angle = 120.0 * unit.degrees
 bb_bb_sc_equil_bond_angle = 120.0 * unit.degrees
+bb_sb_sc_equil_bond_angle = 120.0 * unit.degrees
 equil_bond_angles = {
     "bb_bb_bb_angle_0": bb_bb_bb_equil_bond_angle,
     "bb_bb_sc_angle_0": bb_bb_sc_equil_bond_angle,
     "bb_sc_sc_angle_0": bb_bb_sc_equil_bond_angle,
 }
 
-# Torsion angle definitions                                                                                                     
+# Torsion angle definitions
 torsion_force_constant = 0 * unit.kilojoule_per_mole
 torsion_force_constants = {
     "bb_bb_bb_bb_torsion_k": torsion_force_constant,
     "bb_bb_bb_sc_torsion_k": torsion_force_constant,
-    "bb_bb_sc_sc_torsion_k": torsion_force_constant
+    "bb_bb_sc_sc_torsion_k": torsion_force_constant,
 }
 
-equil_torsion_angle = 0.0 * unit.degrees
 
+equil_torsion_angle = 0.0 * unit.degrees
 equil_torsion_angles = {
-    "bb_bb_bb_bb_torsion_0":equil_torsion_angle,
-    "bb_bb_bb_sc_torsion_0":equil_torsion_angle,
-    "bb_bb_sc_sc_torsion_0":equil_torsion_angle
+    "bb_bb_bb_bb_torsion_0": equil_torsion_angle,
+    "bb_bb_bb_sc_torsion_0": equil_torsion_angle,
+    "bb_bb_sc_sc_torsion_0": equil_torsion_angle,
 }
 torsion_periodicities = {
     "bb_bb_bb_bb_period": 3,
     "bb_bb_bb_sc_period": 1,
-    "bb_bb_bb_sc_period": 1
-}
+    "bb_bb_sc_sc_period": 1}
 
 # Build a coarse grained model
 cgmodel = CGModel(
@@ -97,15 +98,12 @@ cgmodel = CGModel(
     constrain_bonds=constrain_bonds,
     random_positions=random_positions,
 )
-import pdb
-pdb.set_trace()
-#file_name = "12mer_3b1s_initial_structure.pdb"
-#file_name = "12mer_1b1s_initial_structure.pdb"
-file_name = "24mer_1b1s_initial_structure.pdb"
-#file_name = "12mer_1b2s_initial_structure.pdb"  # this one looks a bit off, and takes a long time
-#file_name = "12mer_2b1s_initial_structure.pdb"
-#file_name = "12mer_2b2s_initial_structure.pdb"
+file_name = "12mer_3b1s_initial_structure.pdb"
+# file_name = "12mer_1b1s_initial_structure.pdb"
+# file_name = "24mer_1b1s_initial_structure.pdb"
+# file_name = "12mer_1b2s_initial_structure.pdb"  # this one looks a bit off, and takes a long time
+# file_name = "12mer_2b1s_initial_structure.pdb"
+# file_name = "12mer_2b2s_initial_structure.pdb"
 
 
 write_pdbfile_without_topology(cgmodel, file_name)
-

--- a/examples/generate_random_structures/get_initial_structure.py
+++ b/examples/generate_random_structures/get_initial_structure.py
@@ -4,25 +4,25 @@ from foldamers.cg_model.cgmodel import CGModel
 from cg_openmm.utilities.iotools import write_pdbfile_without_topology
 
 # Coarse grained model settings
-polymer_length = 12
+polymer_length = 24
 backbone_lengths = [1]
 sidechain_lengths = [1]
 sidechain_positions = [0]
-include_bond_forces = False
+include_bond_forces = True
 include_bond_angle_forces = True
 include_nonbonded_forces = True
-include_torsion_forces = True
-constrain_bonds = True
+include_torsion_forces = False  # not sure why, but these need to be off for now.
+constrain_bonds = False
 random_positions = True
 
 # Bond definitions
-bond_length = 1.5 * unit.angstrom
+bond_length = 1.0 * unit.angstrom
 bond_lengths = {
     "bb_bb_bond_length": bond_length,
     "bb_sc_bond_length": bond_length,
     "sc_sc_bond_length": bond_length,
 }
-bond_force_constant = 0 * unit.kilocalorie_per_mole / unit.nanometer / unit.nanometer
+bond_force_constant = 500.0 * unit.kilojoules_per_mole / unit.nanometer / unit.nanometer
 bond_force_constants = {
     "bb_bb_bond_k": bond_force_constant,
     "bb_sc_bond_k": bond_force_constant,
@@ -32,37 +32,47 @@ bond_force_constants = {
 # Particle definitions
 mass = 100.0 * unit.amu
 masses = {"backbone_bead_masses": mass, "sidechain_bead_masses": mass}
-r_min = 3.0 * bond_length  # Lennard-Jones potential r_min
+r_min = 2.0 * bond_length  # Lennard-Jones potential r_min
 sigma = r_min / (2.0 ** (1 / 6))  # Factor of /(2.0**(1/6)) is applied to convert r_min to sigma
 sigmas = {"bb_sigma": sigma, "sc_sigma": sigma}
-epsilon = 0.5 * unit.kilocalorie_per_mole
+epsilon = 0.1 * unit.kilojoule_per_mole
 epsilons = {"bb_eps": epsilon, "sc_eps": epsilon}
 
 # Bond angle definitions
-bond_angle_force_constant = 0.5 * unit.kilocalorie_per_mole / unit.radian / unit.radian
+bond_angle_force_constant = 15.0 * unit.kilojoules_per_mole / unit.radian / unit.radian
 bond_angle_force_constants = {
     "bb_bb_bb_angle_k": bond_angle_force_constant,
     "bb_bb_sc_angle_k": bond_angle_force_constant,
+    "bb_sc_sc_angle_k": bond_angle_force_constant,
 }
-bb_bb_bb_equil_bond_angle = 120.0 * (
-    3.14 / 180.0
-)  # OpenMM requires angle definitions in units of radians
-bb_bb_sc_equil_bond_angle = 120.0 * (3.14 / 180.0)
+bb_bb_bb_equil_bond_angle = 120.0 * unit.degrees
+bb_bb_sc_equil_bond_angle = 120.0 * unit.degrees
 equil_bond_angles = {
     "bb_bb_bb_angle_0": bb_bb_bb_equil_bond_angle,
     "bb_bb_sc_angle_0": bb_bb_sc_equil_bond_angle,
+    "bb_sc_sc_angle_0": bb_bb_sc_equil_bond_angle,
 }
 
-# Torsion angle definitions
-torsion_force_constant = 0.5 * unit.kilocalorie_per_mole / unit.radian / unit.radian
-torsion_force_constants = {"bb_bb_bb_bb_torsion_k": torsion_force_constant}
-bb_bb_bb_bb_equil_torsion_angle = 78.0 * (
-    3.14 / 180.0
-)  # OpenMM requires angle definitions in units of radians
-bb_bb_bb_sc_equil_torsion_angle = 78.0 * (3.14 / 180.0)
-equil_torsion_angles = {"bb_bb_bb_bb_torsion_0": bb_bb_bb_bb_equil_torsion_angle}
-torsion_periodicities = {"bb_bb_bb_bb_period": 1}
+# Torsion angle definitions                                                                                                     
+torsion_force_constant = 0 * unit.kilojoule_per_mole
+torsion_force_constants = {
+    "bb_bb_bb_bb_torsion_k": torsion_force_constant,
+    "bb_bb_bb_sc_torsion_k": torsion_force_constant,
+    "bb_bb_sc_sc_torsion_k": torsion_force_constant
+}
 
+equil_torsion_angle = 0.0 * unit.degrees
+
+equil_torsion_angles = {
+    "bb_bb_bb_bb_torsion_0":equil_torsion_angle,
+    "bb_bb_bb_sc_torsion_0":equil_torsion_angle,
+    "bb_bb_sc_sc_torsion_0":equil_torsion_angle
+}
+torsion_periodicities = {
+    "bb_bb_bb_bb_period": 3,
+    "bb_bb_bb_sc_period": 1,
+    "bb_bb_bb_sc_period": 1
+}
 
 # Build a coarse grained model
 cgmodel = CGModel(
@@ -87,8 +97,15 @@ cgmodel = CGModel(
     constrain_bonds=constrain_bonds,
     random_positions=random_positions,
 )
+import pdb
+pdb.set_trace()
+#file_name = "12mer_3b1s_initial_structure.pdb"
+#file_name = "12mer_1b1s_initial_structure.pdb"
+file_name = "24mer_1b1s_initial_structure.pdb"
+#file_name = "12mer_1b2s_initial_structure.pdb"  # this one looks a bit off, and takes a long time
+#file_name = "12mer_2b1s_initial_structure.pdb"
+#file_name = "12mer_2b2s_initial_structure.pdb"
 
-file_name = "12mer_initial_structure.pdb"
+
 write_pdbfile_without_topology(cgmodel, file_name)
 
-exit()

--- a/examples/generate_random_structures/get_initial_structure.py
+++ b/examples/generate_random_structures/get_initial_structure.py
@@ -48,7 +48,7 @@ bond_angle_force_constants = {
 
 bb_bb_bb_equil_bond_angle = 120.0 * unit.degrees
 bb_bb_sc_equil_bond_angle = 120.0 * unit.degrees
-bb_sb_sc_equil_bond_angle = 120.0 * unit.degrees
+bb_sc_sc_equil_bond_angle = 120.0 * unit.degrees
 equil_bond_angles = {
     "bb_bb_bb_angle_0": bb_bb_bb_equil_bond_angle,
     "bb_bb_sc_angle_0": bb_bb_sc_equil_bond_angle,

--- a/foldamers/cg_model/cgmodel.py
+++ b/foldamers/cg_model/cgmodel.py
@@ -357,7 +357,15 @@ class CGModel(object):
         self.include_torsion_forces = include_torsion_forces
         self.check_energy_conservation = check_energy_conservation
 
-        # Initialize the monomer types
+        # issue some warnings
+        if len(backbone_lengths) == 0 or len(sidechain_lengths) == 0:
+            print("Error:must have backbone and sidechain length lists at least 1")
+            exit()
+        elif len(backbone_lengths) == 1 and backbone_lengths[0] == 1 and len(sidechain_lengths) == 1 and sidechain_lengths[0]==0:
+            print("Error:Cannot use backbone_lengths = [1] and sidechain_lengths = [0] to create a unbranched polymer")
+            print("Error:Instead use backbone_lengths = [n] and sidechain_lengths = [0], with n>1")
+            exit()            
+            # Initialize the monomer types
         if monomer_types == None:
             self.backbone_lengths = backbone_lengths
             self.sidechain_lengths = sidechain_lengths

--- a/foldamers/cg_model/cgmodel.py
+++ b/foldamers/cg_model/cgmodel.py
@@ -1272,7 +1272,7 @@ class CGModel(object):
     def get_equil_bond_angle(self, angle):
         """
           Determines the correct equilibrium bond angle between three particles, given their indices within the coarse grained model
-        
+
           :param CGModel: CGModel() class object
           :type CGModel: class
 
@@ -1290,8 +1290,11 @@ class CGModel(object):
 
           """
 
-        particle_types = [self.get_particle_type(angle[0]), self.get_particle_type(angle[1]),
-                          self.get_particle_type(angle[2])]
+        particle_types = [
+            self.get_particle_type(angle[0]),
+            self.get_particle_type(angle[1]),
+            self.get_particle_type(angle[2]),
+        ]
 
         equil_bond_angle = None
 
@@ -1300,7 +1303,7 @@ class CGModel(object):
         for i in range(3):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(3):
-            reverse_string_name += particle_types[2-i][0] + particle_types[2-i][4] + "_"
+            reverse_string_name += particle_types[2 - i][0] + particle_types[2 - i][4] + "_"
 
         string_name += "angle_0"
         reverse_string_name += "angle_0"
@@ -1350,9 +1353,12 @@ class CGModel(object):
 
 
           """
-        particle_types = [self.get_particle_type(angle[0]), self.get_particle_type(angle[1]),
-                          self.get_particle_type(angle[2])]
-        
+        particle_types = [
+            self.get_particle_type(angle[0]),
+            self.get_particle_type(angle[1]),
+            self.get_particle_type(angle[2]),
+        ]
+
         bond_angle_force_constant = None
 
         string_name = ""
@@ -1360,7 +1366,7 @@ class CGModel(object):
         for i in range(3):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(3):
-            reverse_string_name += particle_types[2-i][0] + particle_types[2-i][4] + "_"
+            reverse_string_name += particle_types[2 - i][0] + particle_types[2 - i][4] + "_"
 
         string_name += "angle_k"
         reverse_string_name += "angle_k"
@@ -1404,8 +1410,12 @@ class CGModel(object):
 
         """
 
-        particle_types = [self.get_particle_type(torsion[0]), self.get_particle_type(torsion[1]),
-                          self.get_particle_type(torsion[2]), self.get_particle_type(torsion[3])]
+        particle_types = [
+            self.get_particle_type(torsion[0]),
+            self.get_particle_type(torsion[1]),
+            self.get_particle_type(torsion[2]),
+            self.get_particle_type(torsion[3]),
+        ]
 
         torsion_periodicity = None
 
@@ -1414,7 +1424,7 @@ class CGModel(object):
         for i in range(4):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(4):
-            reverse_string_name += particle_types[3-i][0] + particle_types[3-i][4] + "_"
+            reverse_string_name += particle_types[3 - i][0] + particle_types[3 - i][4] + "_"
 
         string_name += "period"
         reverse_string_name += "period"
@@ -1437,7 +1447,9 @@ class CGModel(object):
             print(
                 "ERROR: No torsion periodicity definition was found for the following particle types:"
             )
-            print(f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}-{particle_types[3]}")
+            print(
+                f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}-{particle_types[3]}"
+            )
             print("This means that at least one of the particle types has not been defined.")
             print("Check the names and definitions for the particle types in your model.")
             exit()
@@ -1458,8 +1470,12 @@ class CGModel(object):
              - torsion_force_constant ( `Quantity() <https://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ) - The assigned torsion force constant for the provided particles
 
           """
-        particle_types = [self.get_particle_type(torsion[0]), self.get_particle_type(torsion[1]),
-                          self.get_particle_type(torsion[2]), self.get_particle_type(torsion[3])]
+        particle_types = [
+            self.get_particle_type(torsion[0]),
+            self.get_particle_type(torsion[1]),
+            self.get_particle_type(torsion[2]),
+            self.get_particle_type(torsion[3]),
+        ]
 
         torsion_force_constant = None
 
@@ -1468,7 +1484,7 @@ class CGModel(object):
         for i in range(4):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(4):
-            reverse_string_name += particle_types[3-i][0] + particle_types[3-i][4] + "_"
+            reverse_string_name += particle_types[3 - i][0] + particle_types[3 - i][4] + "_"
 
         string_name += "torsion_k"
         reverse_string_name += "torsion_k"
@@ -1491,7 +1507,9 @@ class CGModel(object):
             print(
                 "ERROR: No torsion force constant definition was found for the following particle types:"
             )
-            print(f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}-{particle_types[3]}")
+            print(
+                f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}-{particle_types[3]}"
+            )
             print("This means that at least one of the particle types has not been defined.")
             print("Check the names and definitions for the particle types in your model.")
             exit()
@@ -1512,8 +1530,12 @@ class CGModel(object):
              - equil_torsion_angle (float) - The assigned equilibrium torsion angle for the provided particles
 
           """
-        particle_types = [self.get_particle_type(torsion[0]), self.get_particle_type(torsion[1]),
-                          self.get_particle_type(torsion[2]), self.get_particle_type(torsion[3])]
+        particle_types = [
+            self.get_particle_type(torsion[0]),
+            self.get_particle_type(torsion[1]),
+            self.get_particle_type(torsion[2]),
+            self.get_particle_type(torsion[3]),
+        ]
 
         equil_torsion_angle = None
 
@@ -1522,7 +1544,7 @@ class CGModel(object):
         for i in range(4):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(4):
-            reverse_string_name += particle_types[3-i][0] + particle_types[3-i][4] + "_"
+            reverse_string_name += particle_types[3 - i][0] + particle_types[3 - i][4] + "_"
 
         string_name += "torsion_0"
         reverse_string_name += "torsion_0"
@@ -1545,7 +1567,9 @@ class CGModel(object):
             print(
                 "ERROR: No equilibrium torsion angle definition was found for the following particle types:"
             )
-            print(f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}-{particle_types[3]}")
+            print(
+                f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}-{particle_types[3]}"
+            )
             print("This means that at least one of the particle types has not been defined.")
             print("Check the names and definitions for the particle types in your model.")
             exit()

--- a/foldamers/cg_model/cgmodel.py
+++ b/foldamers/cg_model/cgmodel.py
@@ -1,4 +1,3 @@
-
 import simtk.unit as unit
 import sys, os
 from collections import Counter
@@ -1234,15 +1233,15 @@ class CGModel(object):
         particle_2_type = self.get_particle_type(bond[1])
 
         if particle_1_type == "backbone" and particle_2_type == "backbone":
-            string_name = reverse_string_name = "bb_bb_bond_length"
+            string_name = reverse_string_name = "bb_bb_bond_k"
         if particle_1_type == "backbone" and particle_2_type == "sidechain":
-            string_name = "bb_sc_bond_length"
-            reverse_string_name = "sc_bb_bond_length"
+            string_name = "bb_sc_bond_k"
+            reverse_string_name = "sc_bb_bond_k"
         if particle_1_type == "sidechain" and particle_2_type == "backbone":
-            string_name = "sc_bb_bond_length"
-            reverse_string_name = "bb_sc_bond_length"
+            string_name = "sc_bb_bond_k"
+            reverse_string_name = "bb_sc_bond_k"
         if particle_1_type == "sidechain" and particle_2_type == "sidechain":
-            string_name = reverse_string_name = "sc_sc_bond_length"
+            string_name = reverse_string_name = "sc_sc_bond_k"
 
         bond_force_constant = None
 
@@ -1273,7 +1272,7 @@ class CGModel(object):
     def get_equil_bond_angle(self, angle):
         """
           Determines the correct equilibrium bond angle between three particles, given their indices within the coarse grained model
-
+        
           :param CGModel: CGModel() class object
           :type CGModel: class
 
@@ -1291,10 +1290,8 @@ class CGModel(object):
 
           """
 
-        particle_types = list()
-        particle_types.append(self.get_particle_type(angle[0]))
-        particle_types.append(self.get_particle_type(angle[1]))
-        particle_types.append(self.get_particle_type(angle[2]))
+        particle_types = [self.get_particle_type(angle[0]), self.get_particle_type(angle[1]),
+                          self.get_particle_type(angle[2])]
 
         equil_bond_angle = None
 
@@ -1303,7 +1300,7 @@ class CGModel(object):
         for i in range(3):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(3):
-            reverse_string_name += particle_types[i][0] + particle_types[i][4] + "_"
+            reverse_string_name += particle_types[2-i][0] + particle_types[2-i][4] + "_"
 
         string_name += "angle_0"
         reverse_string_name += "angle_0"
@@ -1312,7 +1309,7 @@ class CGModel(object):
             equil_bond_angle = self.equil_bond_angles[string_name]
         except:
             try:
-                equil_bond_angles = self.equil_bond_angles[reverse_string_name]
+                equil_bond_angle = self.equil_bond_angles[reverse_string_name]
             except:
                 print(
                     f"No equilibrium bond angle definition provided for '{string_name}', setting '{string_name}'={self.default_angle}"
@@ -1325,13 +1322,7 @@ class CGModel(object):
             print(
                 "ERROR: No equilibrium bond angle definition was found for the following particle types:"
             )
-            print(
-                str(particle_types[0])
-                + " "
-                + str(particle_types[1])
-                + " "
-                + str(particle_types[3])
-            )
+            print(f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}")
             print("This means that at least one of the particle types has not been defined.")
             print("Check the names and definitions for the particle types in your model.")
             exit()
@@ -1359,11 +1350,9 @@ class CGModel(object):
 
 
           """
-        particle_types = list()
-        particle_types.append(self.get_particle_type(angle[0]))
-        particle_types.append(self.get_particle_type(angle[1]))
-        particle_types.append(self.get_particle_type(angle[2]))
-
+        particle_types = [self.get_particle_type(angle[0]), self.get_particle_type(angle[1]),
+                          self.get_particle_type(angle[2])]
+        
         bond_angle_force_constant = None
 
         string_name = ""
@@ -1371,7 +1360,7 @@ class CGModel(object):
         for i in range(3):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(3):
-            reverse_string_name += particle_types[i][0] + particle_types[i][4] + "_"
+            reverse_string_name += particle_types[2-i][0] + particle_types[2-i][4] + "_"
 
         string_name += "angle_k"
         reverse_string_name += "angle_k"
@@ -1393,13 +1382,7 @@ class CGModel(object):
             print(
                 "ERROR: No bond angle force constant definition was found for the following particle types:"
             )
-            print(
-                str(particle_types[0])
-                + " "
-                + str(particle_types[1])
-                + " "
-                + str(particle_types[3])
-            )
+            print(f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}")
             print("This means that at least one of the particle types has not been defined.")
             print("Check the names and definitions for the particle types in your model.")
             exit()
@@ -1420,12 +1403,9 @@ class CGModel(object):
         - torsion_periodicity ( int ) - The periodicity for the input torsion
 
         """
-        particle_1_type = self.get_particle_type(torsion[0])
-        particle_2_type = self.get_particle_type(torsion[1])
-        particle_3_type = self.get_particle_type(torsion[2])
-        particle_4_type = self.get_particle_type(torsion[3])
 
-        particle_types = [particle_1_type, particle_2_type, particle_3_type, particle_4_type]
+        particle_types = [self.get_particle_type(torsion[0]), self.get_particle_type(torsion[1]),
+                          self.get_particle_type(torsion[2]), self.get_particle_type(torsion[3])]
 
         torsion_periodicity = None
 
@@ -1434,7 +1414,7 @@ class CGModel(object):
         for i in range(4):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(4):
-            reverse_string_name += particle_types[i][0] + particle_types[i][4] + "_"
+            reverse_string_name += particle_types[3-i][0] + particle_types[3-i][4] + "_"
 
         string_name += "period"
         reverse_string_name += "period"
@@ -1457,15 +1437,7 @@ class CGModel(object):
             print(
                 "ERROR: No torsion periodicity definition was found for the following particle types:"
             )
-            print(
-                str(particle_1_type)
-                + " "
-                + str(particle_2_type)
-                + " "
-                + str(particle_3_type)
-                + " "
-                + str(particle_4_type)
-            )
+            print(f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}-{particle_types[3]}")
             print("This means that at least one of the particle types has not been defined.")
             print("Check the names and definitions for the particle types in your model.")
             exit()
@@ -1486,12 +1458,8 @@ class CGModel(object):
              - torsion_force_constant ( `Quantity() <https://docs.openmm.org/development/api-python/generated/simtk.unit.quantity.Quantity.html>`_ ) - The assigned torsion force constant for the provided particles
 
           """
-        particle_1_type = self.get_particle_type(torsion[0])
-        particle_2_type = self.get_particle_type(torsion[1])
-        particle_3_type = self.get_particle_type(torsion[2])
-        particle_4_type = self.get_particle_type(torsion[3])
-
-        particle_types = [particle_1_type, particle_2_type, particle_3_type, particle_4_type]
+        particle_types = [self.get_particle_type(torsion[0]), self.get_particle_type(torsion[1]),
+                          self.get_particle_type(torsion[2]), self.get_particle_type(torsion[3])]
 
         torsion_force_constant = None
 
@@ -1500,7 +1468,7 @@ class CGModel(object):
         for i in range(4):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(4):
-            reverse_string_name += particle_types[i][0] + particle_types[i][4] + "_"
+            reverse_string_name += particle_types[3-i][0] + particle_types[3-i][4] + "_"
 
         string_name += "torsion_k"
         reverse_string_name += "torsion_k"
@@ -1523,15 +1491,7 @@ class CGModel(object):
             print(
                 "ERROR: No torsion force constant definition was found for the following particle types:"
             )
-            print(
-                str(particle_1_type)
-                + " "
-                + str(particle_2_type)
-                + " "
-                + str(particle_3_type)
-                + " "
-                + str(particle_4_type)
-            )
+            print(f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}-{particle_types[3]}")
             print("This means that at least one of the particle types has not been defined.")
             print("Check the names and definitions for the particle types in your model.")
             exit()
@@ -1552,12 +1512,8 @@ class CGModel(object):
              - equil_torsion_angle (float) - The assigned equilibrium torsion angle for the provided particles
 
           """
-        particle_1_type = self.get_particle_type(torsion[0])
-        particle_2_type = self.get_particle_type(torsion[1])
-        particle_3_type = self.get_particle_type(torsion[2])
-        particle_4_type = self.get_particle_type(torsion[3])
-
-        particle_types = [particle_1_type, particle_2_type, particle_3_type, particle_4_type]
+        particle_types = [self.get_particle_type(torsion[0]), self.get_particle_type(torsion[1]),
+                          self.get_particle_type(torsion[2]), self.get_particle_type(torsion[3])]
 
         equil_torsion_angle = None
 
@@ -1566,7 +1522,7 @@ class CGModel(object):
         for i in range(4):
             string_name += particle_types[i][0] + particle_types[i][4] + "_"
         for i in range(4):
-            reverse_string_name += particle_types[i][0] + particle_types[i][4] + "_"
+            reverse_string_name += particle_types[3-i][0] + particle_types[3-i][4] + "_"
 
         string_name += "torsion_0"
         reverse_string_name += "torsion_0"
@@ -1589,15 +1545,7 @@ class CGModel(object):
             print(
                 "ERROR: No equilibrium torsion angle definition was found for the following particle types:"
             )
-            print(
-                str(particle_1_type)
-                + " "
-                + str(particle_2_type)
-                + " "
-                + str(particle_3_type)
-                + " "
-                + str(particle_4_type)
-            )
+            print(f"{particle_types[0]}-{particle_types[1]}-{particle_types[2]}-{particle_types[3]}")
             print("This means that at least one of the particle types has not been defined.")
             print("Check the names and definitions for the particle types in your model.")
             exit()

--- a/foldamers/utilities/util.py
+++ b/foldamers/utilities/util.py
@@ -114,8 +114,8 @@ def attempt_lattice_move(parent_coordinates, bond_length, move_direction_list):
 
     # need to a bit random because of angles - but still doeson't work
     trial_coordinates = parent_coordinates.__deepcopy__(memo={})
-    incrementor = bond_length*((-1)**(move_direction%2) + 0.3*(np.random.random()-0.5))
-    trial_coordinates[move_direction//2] = parent_coordinates[move_direction//2] + incrementor
+    incrementor = bond_length * ((-1) ** (move_direction % 2) + 0.3 * (np.random.random() - 0.5))
+    trial_coordinates[move_direction // 2] = parent_coordinates[move_direction // 2] + incrementor
     move_direction_list.append(move_direction)
 
     return (trial_coordinates, move_direction_list)
@@ -261,9 +261,9 @@ def assign_position_lattice_style(
           - success ( Logical ) - Indicates whether or not a particle was placed successfully.
 
         """
-    saved_positions = positions.__deepcopy__(memo={}) # save our positions
+    saved_positions = positions.__deepcopy__(memo={})  # save our positions
 
-    bond_list = cgmodel.get_bond_list() # buld the bonded and nonbonded lists
+    bond_list = cgmodel.get_bond_list()  # buld the bonded and nonbonded lists
     nonbonded_list = cgmodel.nonbonded_interaction_list
 
     success = False
@@ -276,8 +276,8 @@ def assign_position_lattice_style(
             positions[parent_bead_index], bond_length, move_direction_list
         )
 
-        positions = np.insert(positions,bead_index,new_coordinates,axis=0) * positions.unit
-        
+        positions = np.insert(positions, bead_index, new_coordinates, axis=0) * positions.unit
+
         nonbonded_distance_list = distances(nonbonded_list, positions)
         bonded_distance_list = distances(bond_list, positions)
 
@@ -289,7 +289,9 @@ def assign_position_lattice_style(
                 success = False
 
         if not success:
-            positions = saved_positions # we could not place the monomer, give up, return positions
+            positions = (
+                saved_positions  # we could not place the monomer, give up, return positions
+            )
 
     return (positions, success)
 
@@ -495,11 +497,12 @@ def get_structure_from_library(cgmodel, high_energy=False, low_energy=False):
                     write_pdbfile_without_topology(cgmodel, file_name)
                     cgmodel.topology = get_topology_from_pdbfile(file_name)
                     cgmodel.system = build_system(cgmodel)
+                    #do a little MD after
                     positions_after, energy, simulation = minimize_structure(
                         cgmodel.topology,
                         cgmodel.system,
                         cgmodel.positions,
-                        expand=1000  # expand for 1000 steps after
+                        expand=1000,  # expand for 1000 steps after
                     )
                     cgmodel.positions = positions_after
                     write_pdbfile_without_topology(cgmodel, file_name)
@@ -580,9 +583,7 @@ def get_structure_from_library(cgmodel, high_energy=False, low_energy=False):
     except:
         cgmodel.system = build_system(cgmodel)
         positions, energy, simulation = minimize_structure(
-            cgmodel.topology,
-            cgmodel.system,
-            cgmodel.positions,
+            cgmodel.topology, cgmodel.system, cgmodel.positions,
         )
 
     return positions
@@ -642,13 +643,13 @@ def get_random_positions(
     sequence = cgmodel.sequence
     end_polymer_length = cgmodel.polymer_length
     end_monomer_types_list = cgmodel.monomer_types
-    heteropolymer = cgmodel.heteropolymer
+    heteropolymer = cgmodel.heteropolymer  # doesn't really do anything yet?
     total_attempts = 0
-    distance_cutoff = 0.90 * cgmodel.bond_lengths["bb_bb_bond_length"]
-    lattice_style = True
-    stored_positions = positions[0:1].__deepcopy__(memo={}) 
+    distance_cutoff = 0.80 * cgmodel.bond_lengths["bb_bb_bond_length"]  # haven't examind this much yet
+    lattice_style = True  # the only one implemented now
+    stored_positions = positions[0:1].__deepcopy__(memo={}) # just the first point
     while total_attempts < max_attempts and len(stored_positions) != len(positions):
-        stored_positions = positions[0:1].__deepcopy__(memo={}) # just the first point
+        stored_positions = positions[0:1].__deepcopy__(memo={})  # just the first point
         bead_index = 0
         previous_monomer_bead_list = []
         monomer_index = 0
@@ -662,7 +663,7 @@ def get_random_positions(
                 print(f"Failed to identify a monomer type for monomer #{monomer_index}")
                 exit()
             num_beads_in_monomer = monomer_type["num_beads"]
-            #which beads are in the monomer.
+            # which beads are in the monomer.
             monomer_bead_list = [i for i in range(bead_index, bead_index + num_beads_in_monomer)]
 
             # Build the connectivity (not the positions) of a model one bead longer.
@@ -673,7 +674,7 @@ def get_random_positions(
             # store some information for restart
             stored_positions_last_monomer = stored_positions.__deepcopy__(memo={})
             bead_index_last_monomer = bead_index
-            
+
             # find the bonds in this new monomer
             monomer_bond_list = []
             for bond_index in range(len(bond_list)):
@@ -696,18 +697,18 @@ def get_random_positions(
                             else:
                                 monomer_bond_list.append([bond[1], bond[0]])
 
-            # this information is need to know which bonds to back to the last monomer.                    
+            # this information is need to know which bonds to back to the last monomer.
             previous_monomer_bead_list_last_monomer = previous_monomer_bead_list
             previous_monomer_bead_list = monomer_bead_list
 
-            completed_list = [] # list of beads whose positions are assigned.
+            completed_list = []  # list of beads whose positions are assigned.
             while completed_list != monomer_bead_list and not monomer_trapped:
-                 if bead_index == 0:
-                     completed_list.append(bead_index)
-                     bead_index = bead_index + 1
-                 else:
-                     # place the monomers involved in this bond
-                     for bond_index in range(len(monomer_bond_list)):
+                if bead_index == 0:
+                    completed_list.append(bead_index)
+                    bead_index = bead_index + 1
+                else:
+                    # place the monomers involved in this bond
+                    for bond_index in range(len(monomer_bond_list)):
                         bond = monomer_bond_list[bond_index]
                         # place the atoms on a pseudogrid
                         if lattice_style:
@@ -724,7 +725,7 @@ def get_random_positions(
                                 bond[0],
                             )
 
-                        if placement: # if we successfuly placed this atom, move to the next one.
+                        if placement:  # if we successfuly placed this atom, move to the next one.
                             stored_positions = trial_positions
                             completed_list.append(bead_index)
                             bead_index = bead_index + 1
@@ -732,16 +733,14 @@ def get_random_positions(
                             # we tried 6 directions, and we couldn't place it. Trapped!
                             monomer_trapped = True
                             break
-                        
+
             if monomer_trapped:
-                # there is no way to go - start over.
-                # Eventually, put in place to back up recursively.
+                # there is no way to go - start over with the first monomer.
+                # Eventually, put in place to back up recursively, rather than starting over.
                 print(f"monomer {monomer_index} trapped; starting over")
-                # start over the whole process.
-                total_attempts +=1
+                total_attempts += 1
                 continue
 
-            
             # We've added a new monomer.
             # Now check for collisions for the entire polymer
 
@@ -750,18 +749,17 @@ def get_random_positions(
 
             # are the new monomers too close to any of the previous monomers?
             collision = False
-            distance_cutoff = 0.80 * cgmodel.bond_lengths["bb_bb_bond_length"]
-            #exclusions_distance_list = distances(cgmodel.get_nonbonded_exclusion_list(), trial_positions)
-            #if collisions(exclusions_distance_list, distance_cutoff):
-            #    collision = True
-            nonbonded_distance_list = distances(cgmodel.get_nonbonded_interaction_list(), trial_positions)
+            nonbonded_distance_list = distances(
+                cgmodel.get_nonbonded_interaction_list(), trial_positions
+            )
             if collisions(nonbonded_distance_list, distance_cutoff):
                 collision = True
 
             if collision:
+                # check if anything is too close
                 print("Error, a particle was placed, but collisions were detected.")
                 print(f"The trial positions are: {trial_positions}")
-                print(f"Backing up")  # backing up
+                print(f"Backing up")  # backing up to the last monomer, build this one again.
                 total_attempts += 1
                 stored_positions = stored_positions_last_monomer
                 bead_index = bead_index_last_monomer
@@ -771,29 +769,33 @@ def get_random_positions(
                     print(f"Monomer {monomer_index} is too hard to place, starting over.")
                     break
             else:
+                # if nothing is too close, build the system up to now and minimize the energy
                 cgmodel.system = build_system(cgmodel)
                 stored_positions, energy, simulation = minimize_structure(
-                    cgmodel.topology,
-                    cgmodel.system,
-                    stored_positions,
+                    cgmodel.topology, cgmodel.system, stored_positions,
                 )
-                monomer_index +=1
+                monomer_index += 1
+                #success!  check the currrent energy
                 print(f"current energy is {energy}")
+
     positions = stored_positions
+    # check for collisions again
     nonbonded_list = cgmodel.nonbonded_interaction_list
     nonbonded_distance_list = distances(nonbonded_list, positions)
     bonded_list = cgmodel.bond_list
     bonded_distance_list = distances(bonded_list, positions)
-    if len(nonbonded_distance_list) > 0 and not collisions(nonbonded_distance_list, distance_cutoff):
+    if len(nonbonded_distance_list) > 0 and not collisions(
+        nonbonded_distance_list, distance_cutoff
+    ):
+        #minimize the whole thing again to check
         cgmodel.positions = positions
         cgmodel.topology = build_topology(cgmodel, use_pdbfile=True)
         cgmodel.system = build_system(cgmodel)
         positions, energy, simulation = minimize_structure(
-            cgmodel.topology,
-            cgmodel.system,
-            positions,
+            cgmodel.topology, cgmodel.system, positions,
         )
 
+        # good to go!
         return positions
 
     else:


### PR DESCRIPTION
A number of changes to get random polymer builds working, plus a few other things that came up along the way. 

- examples/generate_random_structures/get_initial_structure.py is revised for building, including cleaning up some units issues. Torsion forces must be off, for some reason - it results in nan forces even when the torsion force constant (and resulting energies) are zero. However, the structures run fine with torsion potentials added in.   Seem to only be a problem at the beginning.
   - Several example .pdbs built with various numbers of backbone and sidechains
   -  It is not particularly fast or efficient; when a monomer fails to place, it goes back to the beginning, and it probably should back up recursively instead.  But it's OK for builds < 30 for some patterns, and at least 10-12 for others within a few min.   
   - For some reason, the build must be run with torsions off, or it will crash. 
 - in cgmodel.py, some fixes to the get force parameter calls that were screwed up before, along with some extra format cleaning to make it more concise.
 - Most of the changes in utilities/util.py.  I tried to streamline in quite a bit and add in comments, and added a little randomness in the directions.  I removed some error outputting where it really shouldn't reach, and removed extra code in a few functions that wasn't being used (like the positions argument in the collisions helper function.
   - I kept the logic mostly the same for the random build, though removed some steps. Logic is explained better in comments there.
    - I'm sure this could be further cleaned up - this is just to the point that it can produce oligomers of different shapes for testing.
    - Many of the code paths have not really been touched.